### PR TITLE
Replace #tail by its implementation

### DIFF
--- a/src/peruse/lib.rs
+++ b/src/peruse/lib.rs
@@ -1,5 +1,3 @@
-#![feature(collections)]
-
 extern crate regex;
 
 

--- a/src/peruse/slice_parsers.rs
+++ b/src/peruse/slice_parsers.rs
@@ -101,7 +101,7 @@ impl<T: Eq + Clone> SliceParser for LiteralParser< T> {
       return Err(format!("ran out of data"))
     }
     if data[0] == self.literal {
-      Ok((data[0].clone(), data.tail()))
+      Ok((data[0].clone(), &data[1..]))
     } else {
       Err(format!("Literal mismatch"))
     }


### PR DESCRIPTION
Hi, although I see that you only run on nightly, this is the only change necessary to run on beta 2. It just uses the internal implementation of `tail()`.